### PR TITLE
Fix occasional error when adding route

### DIFF
--- a/pkg/routes_linux.go
+++ b/pkg/routes_linux.go
@@ -71,7 +71,7 @@ func routeAdd(dst interface{}, gw net.IP, priority int, iface string) error {
 		}
 		route.LinkIndex = link.Attrs().Index
 	}
-	if err := netlink.RouteAdd(&route); err != nil {
+	if err := netlink.RouteReplace(&route); err != nil {
 		return fmt.Errorf("failed to add %s route to %q interface: %s", dst, iface, err)
 	}
 	return nil

--- a/pkg/routes_unix.go
+++ b/pkg/routes_unix.go
@@ -35,6 +35,8 @@ func routeGet(dst net.IP) ([]net.IP, error) {
 }
 
 func routeAdd(dst interface{}, gw net.IP, priority int, iface string) error {
+	// an implementation of "replace"
+	routeDel(dst, gw, priority, iface)
 	args := []string{
 		"-n",
 		"add",


### PR DESCRIPTION
The error
`failed to add xxx.xxx.xxx.xxx route to "tun0" interface: file exists`
is shown if the route exists from a previous invocation and things weren't cleaned up (e.g. SIGKILL).

Using RouteReplace() instead of RouteAdd() is more resilient to this error.