### PR TITLE
Change: remove resolv.conf if it didn't exist previously

### DIFF
--- a/pkg/config.go
+++ b/pkg/config.go
@@ -190,7 +190,7 @@ func readConfig() (*Config, error) {
 	if !config.DisableDNS {
 		// read current resolv.conf
 		config.resolvConf, err = ioutil.ReadFile(resolvPath)
-		if err != nil {
+		if !(err == nil || os.IsNotExist(err)) {
 			return nil, fmt.Errorf("cannot read %s: %s", resolvPath, err)
 		}
 	}

--- a/pkg/resolv_all.go
+++ b/pkg/resolv_all.go
@@ -7,11 +7,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 )
 
 func configureDNS(config *Config) error {
-	dns := bytes.NewBufferString("# created by gof5 VPN client\n")
+	dns := bytes.NewBufferString(fmt.Sprintf("# created by gof5 VPN client (PID %d)\n", os.Getpid()))
 
 	if len(config.DNS) == 0 {
 		log.Printf("Forwarding DNS requests to %q", config.f5Config.Object.DNS)
@@ -38,10 +39,14 @@ func configureDNS(config *Config) error {
 }
 
 func restoreDNS(config *Config) {
-	if config.resolvConf != nil {
-		log.Printf("Restoring original %s", resolvPath)
-		if err := ioutil.WriteFile(resolvPath, config.resolvConf, 0644); err != nil {
-			log.Printf("Failed to restore %s: %s", resolvPath, err)
+	log.Printf("Restoring original %s", resolvPath)
+	if config.resolvConf == nil {
+		if err := os.Remove(resolvPath); err != nil {
+			log.Println(err)
 		}
+		return
+	}
+	if err := ioutil.WriteFile(resolvPath, config.resolvConf, 0666); err != nil {
+		log.Printf("Failed to restore %s: %s", resolvPath, err)
 	}
 }


### PR DESCRIPTION
Hi, a new approach. As WriteFile doesn't change the permissions anyway, if the file exists already, I'm fine with 0644, if
we created it. Because in this case we can consider it as private to the application and are free to choose any useful value.
Thinking about this brought me to another shortcoming of the current resolvconf handling: if it doesn't exist before starting gof5, it shouldn't exist after gof5 exists. Systems w/o `resolv.conf` are not considered broken. They use 127.0.0.1 as the nameserver.
Maybe if we're faced with a missing `resolv.conf`, we should add 127.0.0.1 and ::1 to the internal list of DNS servers.

But anyway, for now only handling the "missing" `resolv.conf`:

Note: If the resolv.conf didn't exist previously, we consider the freshly
created resolv.conf as private to gof5 and use mode 0644, and remove it
on exit.

(The 0644 is still subject to umask. If you've the strong feeling, that
0666+umask is the right value, please contact me.)

If it exists, we do not touch the owner and permissions, but the
content.