### PR TITLE
Catch HUP signal

### DIFF
--- a/pkg/client.go
+++ b/pkg/client.go
@@ -551,7 +551,7 @@ func Connect(server, username, password, sessionID string, closeSession, sel boo
 		go link.tunToHTTP()
 	}
 
-	signal.Notify(link.termChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGPIPE)
+	signal.Notify(link.termChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGPIPE, syscall.SIGHUP)
 	<-link.termChan
 
 	link.restoreConfig(config)


### PR DESCRIPTION
The client needs to exit gracefully on receiving HUP. (May happen, if
started inside a SSH session, which dies)