### PR TITLE
Read password masked

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,13 @@ build: fmt vet
 	$(foreach GOARCH,$(GOARCHs),$(shell GOARCH=$(GOARCH) go build -mod=vendor -ldflags="$(LDFLAGS)" -o bin/$(APP_NAME)_$(GOOS)_$(GOARCH)$(SUFFIX) ./cmd/gof5))
 
 docker:
-	docker run -ti --rm -e GOCACHE=/tmp -v $(PWD):/$(APP_NAME) -u $(UID):$(UID) --workdir /$(APP_NAME) golang:latest make
+	docker run -ti --rm -e GOCACHE=/tmp -v $(PWD):/$(APP_NAME) -u $(UID):$(UID) --workdir /$(APP_NAME) golang:1.16 make
 
 fmt:
 	gofmt -s -w cmd pkg
 
 vet:
-	go vet -mod=vendor ./...
+	go vet -mod=vendor ./cmd/... ./pkg/...
 
 static:
 	staticcheck ./cmd/... ./pkg/...

--- a/pkg/client/http.go
+++ b/pkg/client/http.go
@@ -248,7 +248,7 @@ func login(c *http.Client, server string, username, password *string) error {
 	}
 	if *password == "" {
 		fmt.Print("Enter VPN password: ")
-		v, err := gopass.GetPasswd()
+		v, err := gopass.GetPasswdMasked()
 		if err != nil {
 			return fmt.Errorf("failed to read password: %s", err)
 		}


### PR DESCRIPTION
This way an asterisk is shown for each input character
```shell
$ gof5
2021/03/10 09:22:07 gof5 v0.1.2-8-gdd4451f compiled with go1.16 for linux/amd64
2021/03/10 09:22:07 Reusing saved HTTPS VPN session for my-vpn-server.example.com
Enter VPN password: ********
2021/03/10 09:22:27 Logging in...
```

I find it helpful to detect that my keyboard numpad was disabled.

Also, I am setting the golang image version explicitly to 1.16. Otherwise the locally available `latest` version is used, but it can be older minor version, e.g. 1.15, and then the build can fail with 
```shell
docker run -ti --rm -e GOCACHE=/tmp -v /home/vpnachev/go/src/github.com/kayrus/gof5:/gof5 -u 1001:1001 --workdir /gof5 golang:latest make
gofmt -s -w cmd pkg
go vet -mod=vendor ./cmd/... ./pkg/...
vendor/github.com/kayrus/tuncfg/resolv/resolv.go:6:2: cannot find package "." in:
        /gof5/vendor/io/fs
make: *** [Makefile:32: vet] Error 1
Makefile:26: recipe for target 'docker' failed
make: *** [docker] Error 2
```

And lastly, the `go vet` does not need to run against the `vendor` dir.