### PR TITLE
fixDisableDNS

### DIFF
--- a/pkg/link/link.go
+++ b/pkg/link/link.go
@@ -323,12 +323,14 @@ func (l *vpnLink) WaitAndConfig(cfg *config.Config) {
 	}
 
 	// exclude local DNS servers, when they are not located inside the LAN
-	for _, v := range l.resolvHandler.GetOriginalDNS() {
-		localDNS := &net.IPNet{
-			IP:   v,
-			Mask: net.CIDRMask(32, 32),
+	if !cfg.DisableDNS {
+		for _, v := range l.resolvHandler.GetOriginalDNS() {
+			localDNS := &net.IPNet{
+				IP:   v,
+				Mask: net.CIDRMask(32, 32),
+			}
+			routes.RemoveNet(localDNS)
 		}
-		routes.RemoveNet(localDNS)
 	}
 
 	var gw net.IP


### PR DESCRIPTION
Hi!

i think i've found a small bug when setting `disableDNS: true` in `config.yaml`:

```
root@prdtun139:~# ./gof5_linux_amd64  --server https://XXXXXXX --username XXXXXXX --password XXXXXXXXX
2021/07/29 16:51:07 gof5 v0.1.3-6-gda6e8ac compiled with go1.16.2 for linux/amd64
2021/07/29 16:51:07 Reusing saved HTTPS VPN session for XXXXXXXXXXXXXXXXX
2021/07/29 16:51:07 Found F5 VPN profiles: ["0:/Common/bcs-vpn.access_profile_ADAuth_custom_portalaccess-vpn-bcs.network_access"]
2021/07/29 16:51:07 Using "/Common/bcs-vpn.access_profile_ADAuth_custom_portalaccess-vpn-bcs.network_access" F5 VPN profile
2021/07/29 16:51:08 MTU: 1411
2021/07/29 16:51:08 Magic: 528e4b49
2021/07/29 16:51:08 PFC: 0702
2021/07/29 16:51:08 ACFC: 0802
2021/07/29 16:51:08 id: 1, IPV6 accepted
2021/07/29 16:51:08 id: 2, MTU accepted
2021/07/29 16:51:08 id: 1, id2: 3, Remote IPv4 requested: 1.1.1.1
2021/07/29 16:51:08 id: 1, id2: 1, Remote IPv6 requested: fe80::6cc0:a6a0:34:f40d
2021/07/29 16:51:08 id: 1, id2: 3, Local IPv4 not acknowledged: 172.16.82.115
2021/07/29 16:51:08 id: 1, id2: 3, Local IPv4 acknowledged: 172.16.82.115
2021/07/29 16:51:08 Using wireguard module to create tunnel
2021/07/29 16:51:08 Created tun0 interface
2021/07/29 16:51:08 Setting routes on tun0 interface
2021/07/29 16:51:08 Applying routes, pushed from F5 VPN server
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x88 pc=0x887b0c]


goroutine 30 [running]:
github.com/kayrus/tuncfg/resolv.(*Handler).GetOriginalDNS(...)
        github.com/kayrus/tuncfg@v0.0.0-20210314181855-c4c275404a9a/resolv/resolv.go:166
github.com/kayrus/gof5/pkg/link.(*vpnLink).WaitAndConfig(0xc00022b0e0, 0xc0000b2630)
        github.com/kayrus/gof5/pkg/link/link.go:326 +0x1cc
created by github.com/kayrus/gof5/pkg/client.Connect
        github.com/kayrus/gof5/pkg/client/client.go:177 +0xcd9

```

looking at the code in `pkg/link/link.go:326` seems to me pretty straight forward that there is an if statement missing in that block, 

adding the `if !cfg.DisableDNS {` seems to fix the issue.